### PR TITLE
Update ImageNet-C leaderboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ ImageNet-C Robustness with a ResNet-50 Backbone
 
 |                Method               |                              Reference                             |   mCE   |    Clean Error |
 |-------------------------------------|--------------------------------------------------------------------|:-------:| :-------:|
+| [Assemble-Resnet50](https://github.com/clovaai/assembled-cnn) | [Lee et al.](https://arxiv.org/abs/2001.06268) | 54.1%   |  17.31%
 | [AugMix](https://github.com/google-research/augmix) | [Hendrycks and Mu et al.](https://arxiv.org/pdf/1912.02781.pdf) (ICLR 2020) | 65.3%   |  22.47%
 | Stylized ImageNet Data Augmentation | [Geirhos et al.](https://arxiv.org/pdf/1811.12231.pdf) (ICLR 2019) | 69.3%   |  25.41%
 | Patch Uniform | [Lopes et al.](https://arxiv.org/abs/1906.02611)  | 74.3%   |  24.5%


### PR DESCRIPTION
from https://github.com/hendrycks/robustness/pull/25#issuecomment-579970366

> In AugMix, contrast, color, brightness, sharpness, were withheld. If the augmentation method has some restrictions, I will add the results.

@hendrycks  Thank for your review.
In that case, our result without autoaugment satisfies the condition(**E10** in below table from [our paper](https://arxiv.org/abs/2001.06268)).
We updated the PR 

![image](https://user-images.githubusercontent.com/1518919/73417827-d488aa80-435c-11ea-93de-2aa561ccc1b0.png)
