### PR TITLE
Add "Adversarial Noise Training" to leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ ImageNet-C Robustness with a ResNet-50 Backbone
 |                Method               |                              Reference                             |   mCE   |    Clean Error |
 |-------------------------------------|--------------------------------------------------------------------|:-------:| :-------:|
 | [Assemble-ResNet50](https://github.com/clovaai/assembled-cnn) | [Lee et al.](https://arxiv.org/abs/2001.06268) | 56.5%   |  17.90%
+| [Adversarial Noise Training & Stylization](https://github.com/bethgelab/game-of-noise) | [Rusak et al.](https://arxiv.org/abs/2001.06057) | 61.2%   |  25.13%
 | [AugMix](https://github.com/google-research/augmix) | [Hendrycks and Mu et al.](https://arxiv.org/pdf/1912.02781.pdf) (ICLR 2020) | 65.3%   |  22.47%
 | Stylized ImageNet Data Augmentation | [Geirhos et al.](https://arxiv.org/pdf/1811.12231.pdf) (ICLR 2019) | 69.3%   |  25.41%
 | Patch Uniform | [Lopes et al.](https://arxiv.org/abs/1906.02611)  | 74.3%   |  24.5%


### PR DESCRIPTION
Add "Adversarial Noise Training with stylization" to ImageNet-C leaderboard with links to the preprint: https://arxiv.org/abs/2001.06057 and code: https://github.com/bethgelab/game-of-noise